### PR TITLE
Fix client session handling

### DIFF
--- a/src/app/component/videos.tsx
+++ b/src/app/component/videos.tsx
@@ -3,7 +3,6 @@
 import { Avatar } from '@mui/material';
 import styles from '../ui/videos.module.css';
 import { useEffect, useState } from 'react';
-import getSession from '@/lib/session';
 
 interface Video {
   id: string;
@@ -14,9 +13,8 @@ interface Video {
   createdAt: Date;
 }
 
-export default function VideosPage() {
+export default function VideosPage({ isAuthenticated }: { isAuthenticated: boolean }) {
   const [videos, setVideos] = useState<Video[]>([]);
-  const [session, setSession] = useState<boolean>(false); // You can type this properly if you know the session shape
 
   useEffect(() => {
     // Fetch videos from API route
@@ -26,18 +24,7 @@ export default function VideosPage() {
       .catch((err) => console.error('Error fetching videos:', err));
   }, []);
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const userSession = await getSession();
-        setSession(userSession);
-      } catch (err) {
-        console.error('Error fetching session:', err);
-      }
-    })();
-  }, []);
-
-  if (!session) {
+  if (!isAuthenticated) {
     return <div>Please login first</div>;
   }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import Videos from './component/videos';
 import styles from './ui/page.module.css';
-export default function Home() {
+import getSession from '@/lib/session';
+
+export default async function Home() {
+  const isAuthenticated = await getSession();
   return (
       <main className={styles.main}>
-        <Videos />
+        <Videos isAuthenticated={isAuthenticated} />
       </main>
   );
 }


### PR DESCRIPTION
## Summary
- ensure videos page uses a server session check

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee58b7f1483299b518af477e2758e